### PR TITLE
Added new columns to the novel table and implemented Update for ComicbookArchive

### DIFF
--- a/Benny-Scraper.BusinessLogic/FileGenerators/ComicBookArchiveGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/ComicBookArchiveGenerator.cs
@@ -65,7 +65,8 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
                 }
             }
 
-            var outputFilePath = Path.Combine(outputDirectory, $"{sanitzedTitle}.{Enum.GetName(fileExtension)}");
+            var outputFilePath = Path.Combine(outputDirectory, $"{sanitzedTitle}.{Enum.GetName(fileExtension)?.ToLowerInvariant()}");
+            novel.SaveLocation = outputFilePath;
             try
             {
                 File.Delete(Path.Combine(outputDirectory, outputFilePath));

--- a/Benny-Scraper.BusinessLogic/FileGenerators/ComicBookArchiveGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/ComicBookArchiveGenerator.cs
@@ -10,6 +10,14 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
+        /// <summary>
+        /// Creates a single comic book archive, file extension is determined by the configuration.DefaultMangaFileExtension value
+        /// </summary>
+        /// <param name="novel"></param>
+        /// <param name="chapterDataBuffers"></param>
+        /// <param name="outputDirectory"></param>
+        /// <param name="configuration"></param>
+        /// <returns>Location where the archive was saved</returns>
         public string CreateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory, Configuration configuration)
         {
             string comicbookArchiveSaveLocation = string.Empty;
@@ -38,10 +46,56 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
             return comicbookArchiveSaveLocation;
         }
 
-        public string UpdateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory)
+        /// <summary>
+        /// Updates an existing comic book archive with new pages from the novel without needing to re-create the entire archive, if the archive doesn't exist, it will create a new one
+        /// </summary>
+        /// <param name="novel"></param>
+        /// <param name="chapterDataBuffers"></param>
+        /// <param name="outputDirectory"></param>
+        /// <param name="configuration"></param>
+        /// <returns>Location where the archive was saved</returns>
+        public string UpdateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory, Configuration configuration)
         {
-            throw new NotImplementedException();
+            var comicBookArchivePath = novel.SaveLocation;
+
+            if (string.IsNullOrEmpty(comicBookArchivePath) || !File.Exists(comicBookArchivePath))
+                return CreateComicBookArchive(novel, chapterDataBuffers, outputDirectory, configuration); // If the path is null or the file doesn't exist, simply create a new one
+
+            using (FileStream zipFileStream = new FileStream(comicBookArchivePath, FileMode.Open)) // this will directly modify the existing archive without needing to create a temp
+            {
+                using (ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Update))
+                {
+                    foreach (var chapter in chapterDataBuffers)
+                    {
+                        if (chapter.Pages == null)
+                            continue;
+
+                        var imagePaths = chapter.Pages.Select(page => page.ImagePath).ToList();
+
+                        for (int i = 0; i < imagePaths.Count; i++)
+                        {
+                            var imageName = $"Chapter_{chapter.Number}_Page{(i + 1).ToString().PadLeft(chapter.Pages.Count.ToString().Length, '0')}.{Path.GetExtension(imagePaths[i])}";
+
+                            // Delete existing image if it's already in the archive
+                            var existingEntry = archive.GetEntry(imageName);
+                            existingEntry?.Delete();
+
+                            // Add new image
+                            var entry = archive.CreateEntry(imageName);
+                            using (var entryStream = entry.Open())
+                            using (var fileStream = File.OpenRead(imagePaths[i]))
+                            {
+                                fileStream.CopyTo(entryStream);
+                            }
+
+                            File.Delete(imagePaths[i]);
+                        }
+                    }
+                }
+            }
+            return comicBookArchivePath;
         }
+
 
         private static string CreateSigleComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffer, string outputDirectory, FileExtension fileExtension)
         {

--- a/Benny-Scraper.BusinessLogic/FileGenerators/Interfaces/IComicBookArchiveGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/Interfaces/IComicBookArchiveGenerator.cs
@@ -9,6 +9,7 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators.Interfaces
 {
     public interface IComicBookArchiveGenerator
     {
-        public void CreateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory, Configuration configuration);
+        public string CreateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory, Configuration configuration);
+        public string UpdateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory);
     }
 }

--- a/Benny-Scraper.BusinessLogic/FileGenerators/Interfaces/IComicBookArchiveGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/Interfaces/IComicBookArchiveGenerator.cs
@@ -10,6 +10,6 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators.Interfaces
     public interface IComicBookArchiveGenerator
     {
         public string CreateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory, Configuration configuration);
-        public string UpdateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory);
+        public string UpdateComicBookArchive(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffers, string outputDirectory, Configuration configuration);
     }
 }

--- a/Benny-Scraper.BusinessLogic/FileGenerators/PdfGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/PdfGenerator.cs
@@ -23,9 +23,14 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
             Logger.Info(new string('=', 50));
             Console.ForegroundColor = ConsoleColor.Blue;
             if (configuration.SaveAsSingleFile)
+            {
                 CreateSinglePdf(novel, chapterDataBuffers, outputDirectory);
+            }
             else
+            {
                 CreatePdfByChapter(novel, chapterDataBuffers, outputDirectory);
+                novel.SavedFileIsSplit = true;
+            }
 
             Console.Write($"Total chapters: {novel.Chapters.Count}\nTotal pages {totalPages}:\n\nPDF files created at: {outputDirectory}\n");
             if (totalMissingChapters > 0)
@@ -78,6 +83,7 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
 
                 var sanitizedTitle = CommonHelper.SanitizeFileName($"{novel.Title} - {chapter.Title}", true);
                 var pdfFilePath = Path.Combine(pdfDirectoryPath, sanitizedTitle + PdfFileExtension);
+                novel.SaveLocation = pdfFilePath;
                 document.Save(pdfFilePath);
             }
         }
@@ -122,18 +128,36 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
             var sanitizedTitle = CommonHelper.SanitizeFileName(novel.Title, true);
             Logger.Info($"Saving Pdf to {pdfDirectoryPath}");
             var pdfFilePath = Path.Combine(pdfDirectoryPath, sanitizedTitle + PdfFileExtension);
+            novel.SaveLocation = pdfFilePath;
             document.Save(pdfFilePath);
             Logger.Info($"Pdf saved to {pdfFilePath}");
             Console.WriteLine($"Pdf saved to {pdfFilePath}");
         }
 
+        /// <summary>
+        /// Method that will update an existing pdf file with new chapters, does not work with single chapter pdfs
+        /// </summary>
+        /// <param name="novel"></param>
+        /// <param name="chapterDataBuffer"></param>
+        /// <param name="configuration"></param>
+        /// <exception cref="ArgumentException"></exception>
         public void UpdatePdf(Novel novel, IEnumerable<ChapterDataBuffer> chapterDataBuffer, Configuration configuration)
         {
             var pdfFilePath = novel.SaveLocation;
             if (Path.GetExtension(pdfFilePath) != PdfFileExtension)
+            {
+                CommonHelper.DeleteTempFolder(chapterDataBuffer.First().TempDirectory);
                 throw new ArgumentException("The path to the pdf file is not a pdf file. " + pdfFilePath);
+            }
             if (!File.Exists(pdfFilePath))
+<<<<<<< Updated upstream
                 throw new ArgumentException("The path to the pdf file does not exist. " + pdfFilePath);
+=======
+            {
+                CommonHelper.DeleteTempFolder(chapterDataBuffer.First().TempDirectory);
+                throw new ArgumentException("The path to the pdf file does not exist. " + pdfFilePath + "\n Please try to update the save location of the novel by running the command 'benny-scraper -L " + novel.Id + "'");
+            }
+>>>>>>> Stashed changes
 
             var tempPdfFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + PdfFileExtension);
 

--- a/Benny-Scraper.BusinessLogic/FileGenerators/PdfGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/PdfGenerator.cs
@@ -84,8 +84,8 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
 
                 var sanitizedTitle = CommonHelper.SanitizeFileName($"{novel.Title} - {chapter.Title}", true);
                 var pdfFilePath = Path.Combine(pdfDirectoryPath, sanitizedTitle + PdfFileExtension);
-                novel.SaveLocation = pdfFilePath;
                 document.Save(pdfFilePath);
+                novel.SaveLocation = pdfDirectoryPath;
             }
         }
 
@@ -129,8 +129,8 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
             var sanitizedTitle = CommonHelper.SanitizeFileName(novel.Title, true);
             Logger.Info($"Saving Pdf to {pdfDirectoryPath}");
             var pdfFilePath = Path.Combine(pdfDirectoryPath, sanitizedTitle + PdfFileExtension);
-            novel.SaveLocation = pdfFilePath;
             document.Save(pdfFilePath);
+            novel.SaveLocation = pdfFilePath;
             Logger.Info($"Pdf saved to {pdfFilePath}");
             Console.WriteLine($"Pdf saved to {pdfFilePath}");
         }

--- a/Benny-Scraper.BusinessLogic/FileGenerators/PdfGenerator.cs
+++ b/Benny-Scraper.BusinessLogic/FileGenerators/PdfGenerator.cs
@@ -25,6 +25,7 @@ namespace Benny_Scraper.BusinessLogic.FileGenerators
             if (configuration.SaveAsSingleFile)
             {
                 CreateSinglePdf(novel, chapterDataBuffers, outputDirectory);
+                novel.SavedFileIsSplit = false;
             }
             else
             {

--- a/Benny-Scraper.BusinessLogic/NovelProcessor.cs
+++ b/Benny-Scraper.BusinessLogic/NovelProcessor.cs
@@ -109,8 +109,6 @@ namespace Benny_Scraper.BusinessLogic
             Logger.Info($"Novel {novel.Title} found with url {novelTableOfContentsUri} is in database, updating it now. Novel Id: {novel.Id}");
             if (novel.Chapters.Any(chapter => chapter?.Pages != null))
             {
-                if (string.IsNullOrEmpty(novel.SaveLocation))
-                    novel.SaveLocation = Path.Combine(outputDirectory, CommonHelper.SanitizeFileName(novel.Title) + PdfGenerator.PdfFileExtension);
                 if (configuration.DefaultMangaFileExtension == FileExtension.Pdf)
                     _pdfGenerator.CreatePdf(novel, chapterDataBuffers, outputDirectory, configuration);
                 else
@@ -177,9 +175,11 @@ namespace Benny_Scraper.BusinessLogic
 
             if (newChapters.Any(chapter => chapter?.Pages != null))
             {
-                if (string.IsNullOrEmpty(novel.SaveLocation))
+                // need to figure out how to decide which file type things are then try to update them
+                if (string.IsNullOrEmpty(novel.SaveLocation)) // assume that if the save location is null, then the novel is a pdf and was added before the cbz feature was added
                     novel.SaveLocation = Path.Combine(outputDirectory, CommonHelper.SanitizeFileName(novel.Title) + PdfGenerator.PdfFileExtension);
-                _pdfGenerator.UpdatePdf(novel, chapterDataBuffers, configuration);
+                if (configuration.DefaultMangaFileExtension == FileExtension.Pdf) // might be a good idea to assume a new database is created with more columns on tables to keep track of these things
+                    _pdfGenerator.UpdatePdf(novel, chapterDataBuffers, configuration);
                 foreach (var chapterDataBuffer in chapterDataBuffers)
                 {
                     chapterDataBuffer.Dispose();

--- a/Benny-Scraper.BusinessLogic/NovelProcessor.cs
+++ b/Benny-Scraper.BusinessLogic/NovelProcessor.cs
@@ -117,7 +117,8 @@ namespace Benny_Scraper.BusinessLogic
                 else
                 {
                     _comicBookArchiveGenerator.CreateComicBookArchive(novel, chapterDataBuffers, outputDirectory, configuration);
-                    novel.FileType = (NovelFileType)configuration.DefaultMangaFileExtension;
+                    novel.FileType = Enum.TryParse(configuration.DefaultMangaFileExtension.ToString(), out NovelFileType convertedType)
+                        ? convertedType : NovelFileType.Cbz; // check to see if converting by name works, if not default to cbz
                 }
                 foreach (var chapterDataBuffer in chapterDataBuffers)
                 {

--- a/Benny-Scraper.BusinessLogic/NovelProcessor.cs
+++ b/Benny-Scraper.BusinessLogic/NovelProcessor.cs
@@ -110,9 +110,15 @@ namespace Benny_Scraper.BusinessLogic
             if (novel.Chapters.Any(chapter => chapter?.Pages != null))
             {
                 if (configuration.DefaultMangaFileExtension == FileExtension.Pdf)
+                {
                     _pdfGenerator.CreatePdf(novel, chapterDataBuffers, outputDirectory, configuration);
+                    novel.FileType = NovelFileType.Pdf;
+                }
                 else
+                {
                     _comicBookArchiveGenerator.CreateComicBookArchive(novel, chapterDataBuffers, outputDirectory, configuration);
+                    novel.FileType = (NovelFileType)configuration.DefaultMangaFileExtension;
+                }
                 foreach (var chapterDataBuffer in chapterDataBuffers)
                 {
                     chapterDataBuffer.Dispose();
@@ -121,6 +127,7 @@ namespace Benny_Scraper.BusinessLogic
             else
             {
                 novel.SaveLocation = CreateEpub(novel, novelDataBuffer.ThumbnailImage, outputDirectory);
+                novel.FileType = NovelFileType.Epub;
             }
             await _novelService.UpdateAsync(novel);
         }

--- a/Benny-Scraper.BusinessLogic/NovelProcessor.cs
+++ b/Benny-Scraper.BusinessLogic/NovelProcessor.cs
@@ -207,7 +207,7 @@ namespace Benny_Scraper.BusinessLogic
                     _pdfGenerator.UpdatePdf(novel, chapterDataBuffers, configuration);
             }
             else
-                _comicBookArchiveGenerator.UpdateComicBookArchive(novel, chapterDataBuffers, outputDirectory);
+                _comicBookArchiveGenerator.UpdateComicBookArchive(novel, chapterDataBuffers, outputDirectory, configuration);
             foreach (var chapterDataBuffer in chapterDataBuffers)
             {
                 chapterDataBuffer.Dispose();

--- a/Benny-Scraper.BusinessLogic/Services/Interface/INovelService.cs
+++ b/Benny-Scraper.BusinessLogic/Services/Interface/INovelService.cs
@@ -12,7 +12,7 @@ namespace Benny_Scraper.BusinessLogic.Services.Interface
         public Task<Novel> GetByIdAsync(Guid id);
         public Task<IEnumerable<Novel>> GetAllAsync();
         public Task UpdateAsync(Novel novel);
-        public Task UpdateAndAddChapters(Novel novel, IEnumerable<Chapter> chapters);
+        public Task UpdateAndAddChaptersAsync(Novel novel, IEnumerable<Chapter> chapters);
         public Task RemoveAllAsync();
         public Task RemoveByIdAsync(Guid id);
     }

--- a/Benny-Scraper.BusinessLogic/Services/NovelService.cs
+++ b/Benny-Scraper.BusinessLogic/Services/NovelService.cs
@@ -120,6 +120,8 @@ namespace Benny_Scraper.BusinessLogic.Services
             }
 
             var chapters = await _unitOfWork.Chapter.GetAllAsync(filter: c => c.NovelId == id);
+            //if (pages != null)
+            //    _unitOfWork.Page.RemoveRange(pages);
             _unitOfWork.Chapter.RemoveRange(chapters);
             _unitOfWork.Novel.Remove(novel);
             await _unitOfWork.SaveAsync();

--- a/Benny-Scraper.BusinessLogic/Services/NovelService.cs
+++ b/Benny-Scraper.BusinessLogic/Services/NovelService.cs
@@ -33,7 +33,7 @@ namespace Benny_Scraper.BusinessLogic.Services
         /// <param name="novel"></param>
         /// <param name="newChapters"></param>
         /// <returns></returns>
-        public async Task UpdateAndAddChapters(Novel novel, IEnumerable<Chapter> newChapters)
+        public async Task UpdateAndAddChaptersAsync(Novel novel, IEnumerable<Chapter> newChapters)
         {            
             _unitOfWork.Novel.Update(novel); //update existing
 

--- a/Benny-Scraper.DataAccess/Data/Database.cs
+++ b/Benny-Scraper.DataAccess/Data/Database.cs
@@ -36,6 +36,10 @@ namespace Benny_Scraper.DataAccess.Data
             modelBuilder.Entity<Chapter>().Property(x => x.DateLastModified).HasColumnName("date_last_modified").HasColumnOrder(5);
             modelBuilder.Entity<Chapter>().Property(x => x.Number).HasColumnName("number").HasColumnOrder(6);
             modelBuilder.Entity<Chapter>().Property(x => x.Content).HasColumnName("content").HasColumnOrder(7);
+            modelBuilder.Entity<Chapter>()
+                .HasMany(x => x.Pages)
+                .WithOne(x => x.Chapter)
+                .HasForeignKey(x => x.ChapterId);
 
             modelBuilder.Entity<Novel>().Property(x => x.Id).HasColumnName("id");
             modelBuilder.Entity<Novel>().Property(x => x.Title).HasColumnName("title");
@@ -54,11 +58,20 @@ namespace Benny_Scraper.DataAccess.Data
             modelBuilder.Entity<Novel>().Property(x => x.CurrentChapter).HasColumnName("current_chapter");
             modelBuilder.Entity<Novel>().Property(x => x.LastTableOfContentsUrl).HasColumnName("last_table_of_contents_url");
             modelBuilder.Entity<Novel>().Property(x => x.CurrentChapterUrl).HasColumnName("current_chapter_url");
+            modelBuilder.Entity<Novel>()
+                .HasMany(x => x.Chapters)
+                .WithOne(x => x.Novel)
+                .HasForeignKey(x => x.NovelId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<Page>().Property(x => x.Id).HasColumnName("id");
             modelBuilder.Entity<Page>().Property(x => x.ChapterId).HasColumnName("chapter_id");
             modelBuilder.Entity<Page>().Property(x => x.Url).HasColumnName("url");
             modelBuilder.Entity<Page>().Property(x => x.Image).HasColumnName("image");
+            modelBuilder.Entity<Page>()
+                .HasOne(x => x.Chapter)
+                .WithMany(x => x.Pages)
+                .HasForeignKey(x => x.ChapterId);
 
             modelBuilder.Entity<Configuration>().Property(x => x.Id).HasColumnName("id");
             modelBuilder.Entity<Configuration>().Property(x => x.Name).HasColumnName("name");
@@ -73,8 +86,6 @@ namespace Benny_Scraper.DataAccess.Data
             modelBuilder.Entity<Configuration>().Property(x => x.DefaultMangaFileExtension).HasColumnName("default_manga_file_extension");
             modelBuilder.Entity<Configuration>().Property(x => x.DefaultLogLevel).HasColumnName("default_log_level");
             modelBuilder.Entity<Configuration>().Property(x => x.SaveAsSingleFile).HasColumnName("save_as_single_file");
-
-
         }
         #endregion
 

--- a/Benny-Scraper.DataAccess/DbInitializer/DbInitializer.cs
+++ b/Benny-Scraper.DataAccess/DbInitializer/DbInitializer.cs
@@ -18,26 +18,33 @@ namespace Benny_Scraper.DataAccess.DbInitializer
         /// If there are migrations, apply them
         /// </summary>
         /// <exception cref="Exception"></exception>
-        public void Initialize()
+        public bool Initialize()
         {
+            bool changesMade = false;
             // apply Migrations if they are not applied
             try
             {
                 if (_db.Database.GetPendingMigrations().Any())
                 {
                     _db.Database.Migrate();
+                    changesMade = true;
                 }
 
-                SeedData();
+                if (SeedData())
+                {
+                    changesMade = true;
+                }
             }
             catch (Exception ex)
             {
                 throw new Exception(ex.Message);
             }
+            return changesMade;
         }
 
-        public void SeedData()
+        public bool SeedData()
         {
+            bool dataSeeded = false;
             try
             {
                 if (!_db.Configurations.Any())
@@ -60,12 +67,14 @@ namespace Benny_Scraper.DataAccess.DbInitializer
                     };
                     _db.Configurations.Add(defaultConfig);
                     _db.SaveChanges();
+                    dataSeeded = true;
                 }
             }
             catch (Exception ex)
             {
                 throw new Exception("An error occurred while seeding the database: " + ex.Message, ex);
             }
+            return dataSeeded;
         }
     }
 }

--- a/Benny-Scraper.DataAccess/Migrations/20231024044717_AddFileTypeToNovelTable.Designer.cs
+++ b/Benny-Scraper.DataAccess/Migrations/20231024044717_AddFileTypeToNovelTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Benny_Scraper.DataAccess.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BennyScraper.DataAccess.Migrations
 {
     [DbContext(typeof(Database))]
-    partial class DatabaseModelSnapshot : ModelSnapshot
+    [Migration("20231024044717_AddFileTypeToNovelTable")]
+    partial class AddFileTypeToNovelTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.12");

--- a/Benny-Scraper.DataAccess/Migrations/20231024044717_AddFileTypeToNovelTable.cs
+++ b/Benny-Scraper.DataAccess/Migrations/20231024044717_AddFileTypeToNovelTable.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BennyScraper.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFileTypeToNovelTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FileType",
+                table: "novel",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "SavedFileIsSplit",
+                table: "novel",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FileType",
+                table: "novel");
+
+            migrationBuilder.DropColumn(
+                name: "SavedFileIsSplit",
+                table: "novel");
+        }
+    }
+}

--- a/Benny-Scraper.DataAccess/Migrations/DatabaseModelSnapshot.cs
+++ b/Benny-Scraper.DataAccess/Migrations/DatabaseModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace BennyScraper.DataAccess.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "7.0.11");
+            modelBuilder.HasAnnotation("ProductVersion", "7.0.12");
 
             modelBuilder.Entity("Benny_Scraper.Models.Chapter", b =>
                 {
@@ -194,6 +194,9 @@ namespace BennyScraper.DataAccess.Migrations
                         .HasColumnType("TEXT")
                         .HasColumnName("save_location");
 
+                    b.Property<bool>("SavedFileIsSplit")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("SiteName")
                         .IsRequired()
                         .HasMaxLength(50)
@@ -252,7 +255,7 @@ namespace BennyScraper.DataAccess.Migrations
 
                     b.HasIndex("NovelId");
 
-                    b.ToTable("NovelLists", (string)null);
+                    b.ToTable("NovelLists");
                 });
 
             modelBuilder.Entity("Benny_Scraper.Models.Page", b =>

--- a/Benny-Scraper.DataAccess/Repository/ConfigurationRepository.cs
+++ b/Benny-Scraper.DataAccess/Repository/ConfigurationRepository.cs
@@ -22,4 +22,9 @@ public class ConfigurationRepository : Repository<Configuration>, IConfiguration
     {
         return await _db.Configurations.FindAsync(id);
     }
+
+    public Configuration GetById(int id)
+    {
+        return _db.Configurations.Find(id);
+    }
 }

--- a/Benny-Scraper.DataAccess/Repository/IRepository/IConfigurationRepository.cs
+++ b/Benny-Scraper.DataAccess/Repository/IRepository/IConfigurationRepository.cs
@@ -5,4 +5,5 @@ public interface IConfigurationRepository : IRepository<Configuration>
 {
     void Update(Configuration obj);
     Task<Configuration> GetByIdAsync(int id);
+    Configuration GetById(int id);
 }

--- a/Benny-Scraper.Models/Novel.cs
+++ b/Benny-Scraper.Models/Novel.cs
@@ -36,6 +36,18 @@ namespace Benny_Scraper.Models
         [StringLength(255)]
         public string? SaveLocation { get; set; }
         public bool SavedFileIsSplit { get; set; }
+        public NovelFileType FileType { get; set; }
+    }
+
+    public enum NovelFileType
+    {
+        Epub,
+        Pdf,
+        Cbz,
+        Cbr,
+        Cb7,
+        Cbt,
+        Cba
     }
 
     /// <summary>

--- a/Benny-Scraper.Models/Novel.cs
+++ b/Benny-Scraper.Models/Novel.cs
@@ -33,9 +33,9 @@ namespace Benny_Scraper.Models
         public string? LastTableOfContentsUrl { get; set; }
         [StringLength(50)] public string? Status { get; set; }
 
-
         [StringLength(255)]
         public string? SaveLocation { get; set; }
+        public bool SavedFileIsSplit { get; set; }
     }
 
     /// <summary>

--- a/Benny-Scraper/Program.cs
+++ b/Benny-Scraper/Program.cs
@@ -156,6 +156,10 @@ namespace Benny_Scraper
                 {
                     if (options.List)
                         await ListNovelsAsync();
+                    else if (options.ExtensionType)
+                    {
+                        await GetDefaultMangaExtensionAsync();
+                    }
                     else if (options.ClearDatabase)
                     {
                         var userQuery = string.Format(AreYouSure, "clear the database");
@@ -193,9 +197,16 @@ namespace Benny_Scraper
                         int extension = (int)options.MangaExtension;
                         await SetDefaultMangaExtensionAsync(extension);
                     }
+<<<<<<< Updated upstream
                     else if (options.ExtensionType)
                     {
                         await GetDefaultMangaExtensionAsync();
+=======
+                    else if (string.Equals(options.SingleFile.ToLowerInvariant(), "y", StringComparison.OrdinalIgnoreCase) || string.Equals(options.SingleFile.ToLowerInvariant(), "n", StringComparison.OrdinalIgnoreCase))
+                    {
+                        bool singleFile = options.SingleFile.ToLowerInvariant() == "y";
+                        await SetSingleFileAsync(singleFile);
+>>>>>>> Stashed changes
                     }
                     else
                         Console.WriteLine("Invalid command. Please try again.");


### PR DESCRIPTION
1. Fixed update methods for pdfs, changed the way novels get added to the database so it is easier to determine how they were saved, as individual files or chapter by chapter.
2. Added `file_type` and `saved_file_is_split` to novel table. One to keep track of original file type when a novel is created, and the other to keep track of how the file was created. This was very important when fixing the update pdf by chapter.
3. Implemented `UpdateComicBookArhcive()` method, users can now get their `cbz`, `cbt`'s updated.
4. Restructured `NovelProcessor.cs` update method.
5. Resolved what would have been a future bug where if a user used the command-line options before running the applications, the database would not be populated, which would result in errors.
![image](https://github.com/martial-god/Benny-Scraper/assets/8980094/5c32d741-c3f6-48b6-bd52-75a988a49d4a)
