### PR TITLE
Fix for #25 allowing updates to work for Mangakatana. Added new command line option

### DIFF
--- a/Benny-Scraper.BusinessLogic/NovelProcessor.cs
+++ b/Benny-Scraper.BusinessLogic/NovelProcessor.cs
@@ -184,6 +184,10 @@ namespace Benny_Scraper.BusinessLogic
             novel.TotalChapters = novel.Chapters.Count;
             novel.CurrentChapter = novel.Chapters.LastOrDefault()?.Title;
             novel.CurrentChapterUrl = novel.Chapters.LastOrDefault()?.Url;
+            if (!string.IsNullOrEmpty(novelDataBuffer.NovelUrl))
+                novel.Url = novelDataBuffer.NovelUrl;
+            if (novelDataBuffer.Genres.Count != 0)
+                novel.Genre = string.Join(", ", novelDataBuffer.Genres);
         }
 
         private async Task HandleFileTypeUpdatesAsync(Novel novel, NovelDataBuffer novelDataBuffer, IEnumerable<ChapterDataBuffer> chapterDataBuffers, List<Chapter> newChapters, Configuration configuration, string userOutputDirectory)
@@ -222,6 +226,12 @@ namespace Benny_Scraper.BusinessLogic
                 Logger.Warn($"Novel {novel.Title} with url {novelTableOfContentsUri} is up to date.\n\t\tCurrent chapter: {novelDataBuffer.MostRecentChapterTitle} Novel Id: {novel.Id}");
                 return true;
             }
+            var lastChapter = novel.Chapters.OrderBy(chapter => chapter.Number).ToList().Last();
+            if (lastChapter.Url == novelDataBuffer.CurrentChapterUrl && lastChapter.Title == novelDataBuffer.MostRecentChapterTitle)
+            {
+                Logger.Warn($"Novel {novel.Title} with url {novelTableOfContentsUri} is up to date.\n\t\tCurrent chapter: {novelDataBuffer.MostRecentChapterTitle} Novel Id: {novel.Id}");
+                return true;
+            }
             return false;
         }
 
@@ -256,7 +266,7 @@ namespace Benny_Scraper.BusinessLogic
             {
                 Title = novelDataBuffer.Title ?? string.Empty,
                 Author = novelDataBuffer.Author,
-                Url = novelTableOfContentsUri.ToString(),
+                Url = novelTableOfContentsUri.ToString(), // to handle stale urls, make sure to handle the case when users are able to update from files
                 Genre = string.Join(", ", novelDataBuffer.Genres),
                 Description = string.Join(" ", novelDataBuffer.Description),
                 DateCreated = DateTime.Now,

--- a/Benny-Scraper.BusinessLogic/NovelProcessor.cs
+++ b/Benny-Scraper.BusinessLogic/NovelProcessor.cs
@@ -190,7 +190,7 @@ namespace Benny_Scraper.BusinessLogic
         {
             string outputDirectory = CommonHelper.GetOutputDirectoryForTitle(novel.Title, userOutputDirectory);
 
-            if (newChapters.All(chapter => chapter?.Pages == null) && novel.FileType != NovelFileType.Epub)
+            if (newChapters.All(chapter => chapter?.Pages == null) && novel.FileType == NovelFileType.Epub)
             {
                 novel.SaveLocation = CreateEpub(novel, novelDataBuffer.ThumbnailImage, outputDirectory);
                 await _novelService.UpdateAndAddChaptersAsync(novel, newChapters);

--- a/Benny-Scraper.BusinessLogic/Scrapers/Strategy/LightNovelWorldStrategy.cs
+++ b/Benny-Scraper.BusinessLogic/Scrapers/Strategy/LightNovelWorldStrategy.cs
@@ -52,12 +52,13 @@ namespace Benny_Scraper.BusinessLogic.Scrapers.Strategy
 
             SetBaseUri(_scraperData.SiteTableOfContents);
 
-            var htmlDocument = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
+            var (htmlDocument, uri) = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
             var novelDataBuffer = FetchNovelDataFromTableOfContents(htmlDocument);
+            novelDataBuffer.NovelUrl = uri.ToString();
 
-            _chaptersUri = new Uri(_scraperData.SiteTableOfContents + "/chapters");
+            _chaptersUri = new Uri(uri + "/chapters");
 
-            htmlDocument = await LoadHtmlAsync(_chaptersUri);
+            (htmlDocument, uri) = await LoadHtmlAsync(_chaptersUri);
 
             var decodedHtmlDocument = DecodeHtml(htmlDocument);
 

--- a/Benny-Scraper.BusinessLogic/Scrapers/Strategy/MangaKakalotStrategy.cs
+++ b/Benny-Scraper.BusinessLogic/Scrapers/Strategy/MangaKakalotStrategy.cs
@@ -17,7 +17,7 @@ namespace Benny_Scraper.BusinessLogic.Scrapers.Strategy
             queryBuilder.Append("ajax/manga/list-chapter-volume?id=");
             queryBuilder.Append(novelId);
             Uri uriQueryForChapterUrls = new Uri(queryBuilder.ToString());
-            var htmlDocumentForChapterUrls = await scraperStrategy.LoadHtmlPublicAsync(uriQueryForChapterUrls);
+            var (htmlDocumentForChapterUrls, uri) = await scraperStrategy.LoadHtmlPublicAsync(uriQueryForChapterUrls);
 
             var attributesToFetch = new List<Attr>()
             {
@@ -66,11 +66,12 @@ namespace Benny_Scraper.BusinessLogic.Scrapers.Strategy
             Logger.Info($"Getting novel data for {this.GetType().Name}");
             SetBaseUri(_scraperData.SiteTableOfContents);
 
-            var htmlDocument = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
+            var (htmlDocument, uri) = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
 
             try
             {
                 NovelDataBuffer novelDataBuffer = await BuildNovelDataAsync(htmlDocument);
+                novelDataBuffer.NovelUrl = uri.ToString();
 
                 return novelDataBuffer;
             }

--- a/Benny-Scraper.BusinessLogic/Scrapers/Strategy/MangaKatanaStrategy.cs
+++ b/Benny-Scraper.BusinessLogic/Scrapers/Strategy/MangaKatanaStrategy.cs
@@ -58,11 +58,12 @@ namespace Benny_Scraper.BusinessLogic.Scrapers.Strategy
             Logger.Info($"Getting novel data for {this.GetType().Name}");
             SetBaseUri(_scraperData.SiteTableOfContents);
 
-            var htmlDocument = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
+            var (htmlDocument, uri) = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
 
             try
             {
                 NovelDataBuffer novelDataBuffer = await BuildNovelDataAsync(htmlDocument);
+                novelDataBuffer.NovelUrl = uri.ToString();
 
                 return novelDataBuffer;
             }

--- a/Benny-Scraper.BusinessLogic/Scrapers/Strategy/MangaReaderStrategy.cs
+++ b/Benny-Scraper.BusinessLogic/Scrapers/Strategy/MangaReaderStrategy.cs
@@ -58,11 +58,12 @@ namespace Benny_Scraper.BusinessLogic.Scrapers.Strategy
             Logger.Info($"Getting novel data for {this.GetType().Name}");
             SetBaseUri(_scraperData.SiteTableOfContents);
 
-            var htmlDocument = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
+            var (htmlDocument, uri) = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
 
             try
             {
                 NovelDataBuffer novelDataBuffer = await BuildNovelDataAsync(htmlDocument);
+                novelDataBuffer.NovelUrl = uri.ToString();
 
                 return novelDataBuffer;
             }

--- a/Benny-Scraper.BusinessLogic/Scrapers/Strategy/NovelFullStrategy.cs
+++ b/Benny-Scraper.BusinessLogic/Scrapers/Strategy/NovelFullStrategy.cs
@@ -59,11 +59,12 @@ namespace Benny_Scraper.BusinessLogic.Scrapers.Strategy
             Logger.Info($"Getting novel data for {this.GetType().Name}");
 
             SetBaseUri(_scraperData.SiteTableOfContents);
-            var htmlDocument = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
+            var (htmlDocument, uri) = await LoadHtmlAsync(_scraperData.SiteTableOfContents);
             
             try
             {
                 NovelDataBuffer novelDataBuffer = await BuildNovelDataAsync(htmlDocument);
+                novelDataBuffer.NovelUrl = uri.ToString();
 
                 return novelDataBuffer;
             }

--- a/Benny-Scraper.Models/Novel.cs
+++ b/Benny-Scraper.Models/Novel.cs
@@ -61,6 +61,7 @@ namespace Benny_Scraper.Models
             Description = new List<string>();
             Genres = new List<string>();
             AlternativeNames = new List<string>();
+            NovelUrl = string.Empty;
         }
 
         public string Title { get; set; }
@@ -79,6 +80,7 @@ namespace Benny_Scraper.Models
         public string CurrentChapterUrl { get; set; }
         public string FirstChapter { get; set; }
         public byte[]? ThumbnailImage { get; set; }
+        public string NovelUrl { get; set; }
 
         public void Dispose()
         {

--- a/Benny-Scraper/CommandlineOptions.cs
+++ b/Benny-Scraper/CommandlineOptions.cs
@@ -32,6 +32,9 @@ namespace Benny_Scraper
         [Option('n', "novel-save-location", Required = false, HelpText = "Set novel-specific save location [PATH]. Overrides 'save-location'.")]
         public string NovelSaveLocation { get; set; }
 
+        [Option('x', "novel-extension-by-id", Required = false, HelpText = "Set Extension/File type of a saved novel by using the [ID]. 0 - EPUB, 1 - PDF, 2 -CBZ.")]
+        public Guid NovelExtensionById { get; set; }
+
         [Option('e', "manga-extension", Required = false, Default = -1, HelpText = "Default extension for mangas (any image based novel) [INT] *count starts a 0*. Default is PDF.")]
         [Range(0, 6, ErrorMessage = "Value for {0} must be between {1} and {2}.")] // set to -1 to have a default value that would be false when checking to avoid invalid options using this
         public int MangaExtension { get; set; }

--- a/Benny-Scraper/CommandlineOptions.cs
+++ b/Benny-Scraper/CommandlineOptions.cs
@@ -53,5 +53,8 @@ namespace Benny_Scraper
 
         [Option('S', "search", Required = false, Hidden = true, HelpText = "Search for novel by Title, can seach by partial name [STRING].")]
         public string SearchKeyword { get; set; }
+
+        [Option('u', "upgrade", Required = false, HelpText = "Upgrade the application to the latest version.")]
+        public bool Upgrade { get; set; }
     }
 }


### PR DESCRIPTION
1. Urls and Genres will now be updated when updating a novel
2. In the case that `dbo.novel.current_chapter_url` or `dbo.novel.current_chapter` are empty, on update, the values will be updated.
3. new command line option added. `x`, `novel-extension-by-id`. `Set Extension/File type of a saved novel by using the [ID]. 0 - EPUB, 1 - PDF, 2 -CBZ.`


Closes #25 