### PR TITLE
Update to .NET 8.0 and new -U Command line option UpdateAll 

### DIFF
--- a/Benny-Scraper.BusinessLogic/Benny-Scraper.BusinessLogic.csproj
+++ b/Benny-Scraper.BusinessLogic/Benny-Scraper.BusinessLogic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Benny_Scraper.BusinessLogic</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -17,13 +17,13 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
-    <PackageReference Include="NLog" Version="5.2.4" />
-    <PackageReference Include="Polly" Version="8.0.0" />
+    <PackageReference Include="NLog" Version="5.2.7" />
+    <PackageReference Include="Polly" Version="8.2.0" />
     <PackageReference Include="RecursiveDataAnnotationsValidation" Version="2.0.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
     <PackageReference Include="SeleniumExtras.WaitHelpers" Version="1.0.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
     <PackageReference Include="PdfSharpCore" Version="1.3.62" />
   </ItemGroup>

--- a/Benny-Scraper.DataAccess/Benny-Scraper.DataAccess.csproj
+++ b/Benny-Scraper.DataAccess/Benny-Scraper.DataAccess.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Benny_Scraper.DataAccess</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.12">
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
   </ItemGroup>
 

--- a/Benny-Scraper.DataAccess/DbInitializer/DbInitializer.cs
+++ b/Benny-Scraper.DataAccess/DbInitializer/DbInitializer.cs
@@ -30,7 +30,7 @@ namespace Benny_Scraper.DataAccess.DbInitializer
                     changesMade = true;
                 }
 
-                if (SeedData())
+                if (SeedData().Result)
                 {
                     changesMade = true;
                 }
@@ -42,9 +42,10 @@ namespace Benny_Scraper.DataAccess.DbInitializer
             return changesMade;
         }
 
-        public bool SeedData()
+        public async Task<bool> SeedData()
         {
             bool dataSeeded = false;
+            using var transaction = _db.Database.BeginTransaction();
             try
             {
                 if (!_db.Configurations.Any())
@@ -67,11 +68,13 @@ namespace Benny_Scraper.DataAccess.DbInitializer
                     };
                     _db.Configurations.Add(defaultConfig);
                     _db.SaveChanges();
+                    await transaction.CommitAsync();
                     dataSeeded = true;
                 }
             }
             catch (Exception ex)
             {
+                await transaction.RollbackAsync();
                 throw new Exception("An error occurred while seeding the database: " + ex.Message, ex);
             }
             return dataSeeded;

--- a/Benny-Scraper.DataAccess/Repository/IRepository/IUnitOfWork.cs
+++ b/Benny-Scraper.DataAccess/Repository/IRepository/IUnitOfWork.cs
@@ -1,5 +1,7 @@
 ﻿
 
+using Microsoft.EntityFrameworkCore.Storage;
+
 namespace Benny_Scraper.DataAccess.Repository.IRepository
 {
     /// <summary>
@@ -13,5 +15,6 @@ namespace Benny_Scraper.DataAccess.Repository.IRepository
         IPageRepository Page { get; }
         IConfigurationRepository Configuration { get; }
         Task<int> SaveAsync();
+        IDbContextTransaction BeginTransaction();
     }
 }

--- a/Benny-Scraper.DataAccess/Repository/UnitOfWork.cs
+++ b/Benny-Scraper.DataAccess/Repository/UnitOfWork.cs
@@ -1,5 +1,6 @@
-﻿using Benny_Scraper.DataAccess.Data;
-using Benny_Scraper.DataAccess.Repository.IRepository;
+﻿using Benny_Scraper.DataAccess.Repository.IRepository;
+using Microsoft.EntityFrameworkCore.Storage;
+using Database = Benny_Scraper.DataAccess.Data.Database;
 
 namespace Benny_Scraper.DataAccess.Repository
 {
@@ -27,6 +28,9 @@ namespace Benny_Scraper.DataAccess.Repository
         {
             return _db.SaveChangesAsync();
         }
-
+        public IDbContextTransaction BeginTransaction()
+        {
+            return _db.Database.BeginTransaction();
+        }
     }
 }

--- a/Benny-Scraper.Models/Benny-Scraper.Models.csproj
+++ b/Benny-Scraper.Models/Benny-Scraper.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Benny_Scraper.Models</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Benny-Scraper/Benny-Scraper.csproj
+++ b/Benny-Scraper/Benny-Scraper.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Benny_Scraper</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-      <Version>1.1.1</Version>
+      <Version>1.1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,23 +16,23 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.54" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.12">
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="NLog" Version="5.2.4" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.0" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="NLog" Version="5.2.7" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.15.0" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
     <PackageReference Include="SeleniumExtras.WaitHelpers" Version="1.0.2" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.7" />
     <PackageReference Include="WebDriverManager" Version="2.17.1" />
   </ItemGroup>
 

--- a/Benny-Scraper/CommandlineOptions.cs
+++ b/Benny-Scraper/CommandlineOptions.cs
@@ -56,8 +56,5 @@ namespace Benny_Scraper
 
         [Option('S', "search", Required = false, Hidden = true, HelpText = "Search for novel by Title, can seach by partial name [STRING].")]
         public string SearchKeyword { get; set; }
-
-        [Option('u', "upgrade", Required = false, HelpText = "Upgrade the application to the latest version.")]
-        public bool Upgrade { get; set; }
     }
 }

--- a/Benny-Scraper/CommandlineOptions.cs
+++ b/Benny-Scraper/CommandlineOptions.cs
@@ -56,5 +56,8 @@ namespace Benny_Scraper
 
         [Option('S', "search", Required = false, Hidden = true, HelpText = "Search for novel by Title, can seach by partial name [STRING].")]
         public string SearchKeyword { get; set; }
+
+        [Option('U', "update-all", Required = false, Hidden = true, HelpText = "Updates all non-completed novels in database. Will only update ones that were not modified the same day")]
+        public bool UpdateAll { get; set; }
     }
 }

--- a/Benny-Scraper/Program.cs
+++ b/Benny-Scraper/Program.cs
@@ -33,10 +33,6 @@ namespace Benny_Scraper
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
         private static IContainer Container { get; set; }
         private const string AreYouSure = "Are you sure you want to {0}? (y/n)";
-        private const int MaxTitleWidth = 50;
-        private const string ProgramVersion = "v1.1.1";
-        private const string ReleaseUrl = "https://api.github.com/repos/martial-god/Benny-Scraper/releases/latest";
-        private const string MainProject = "Benny-Scraper.csproj";
 
         public static IConfiguration Configuration { get; set; }
 
@@ -184,10 +180,6 @@ namespace Benny_Scraper
                 var confirmation = Console.ReadLine();
                 if (confirmation.ToLowerInvariant() == "y")
                     await ClearDatabaseAsync();
-            }
-            else if (options.Upgrade)
-            {
-                await CheckAndUpgrade();
             }
             else if (options.DeleteNovelById != Guid.Empty)
             {
@@ -665,91 +657,6 @@ namespace Benny_Scraper
                 Console.WriteLine($"{detail.Key.PadRight(20)} {detail.Value}");
             }
             Console.WriteLine("-------------------");
-        }
-
-        private static async Task CheckAndUpgrade()
-        {
-            using HttpClient client = new HttpClient();
-            string url = ReleaseUrl;
-            client.DefaultRequestHeaders.Add("User-Agent", "Benny-Scraper");
-
-            try
-            {
-                var response = await client.GetStringAsync(url);
-                var jsonResponse = Newtonsoft.Json.Linq.JObject.Parse(response);
-
-                string latestVersion = jsonResponse["tag_name"].ToString();
-                string currentVersion = ProgramVersion;
-                Console.WriteLine($"Current version: {currentVersion}");
-
-                if (string.Compare(latestVersion, currentVersion, StringComparison.InvariantCultureIgnoreCase) > 0)
-                {
-                    Console.WriteLine($"New version {latestVersion} available. Upgrading...");
-
-                    string downloadUrl = jsonResponse["assets"][0]["browser_download_url"].ToString();
-                    string installDir = AppDomain.CurrentDomain.BaseDirectory;
-
-                    if (await DownloadAndUpgradeApp(downloadUrl, installDir))
-                        Console.WriteLine($"Upgraded to version {latestVersion}");
-                    else
-                        Console.WriteLine("Upgrade failed.");
-                }
-                else
-                    Console.WriteLine("You are on the latest version.");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error checking for updates: {ex.Message}");
-            }
-        }
-
-        private static async Task<bool> DownloadAndUpgradeApp(string downloadUrl, string installDirectory)
-        {
-            string tempFile = Path.Combine(Path.GetTempPath(), "appUpdate.zip");
-
-            using (var client = new HttpClient())
-            {
-                var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseContentRead);
-
-                using (var fs = new FileStream(tempFile, FileMode.Create))
-                {
-                    await response.Content.CopyToAsync(fs);
-                }
-            }
-
-            try
-            {
-                string tempDirectory = Path.Combine(Path.GetTempPath(), "appUpdate");
-                if (Directory.Exists(tempDirectory))
-                    Directory.Delete(tempDirectory, true);
-                ZipFile.ExtractToDirectory(tempFile, tempDirectory);
-
-                // Stop services or processes if necessary
-
-                foreach (var file in Directory.GetFiles(tempDirectory))
-                {
-                    string destFile = Path.Combine(installDirectory, Path.GetFileName(file));
-                    if (File.Exists(destFile))
-                        File.Delete(destFile);
-                    File.Move(file, destFile);
-                }
-
-                foreach (var dir in Directory.GetDirectories(tempDirectory))
-                {
-                    string destDir = Path.Combine(installDirectory, new DirectoryInfo(dir).Name);
-                    Directory.Move(dir, destDir);
-                }
-
-                File.Delete(tempFile);
-                Directory.Delete(tempDirectory, true);
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error during upgrade: {ex.Message}");
-                return false;
-            }
         }
 
         private static async Task UpdateNovelFileType(Guid id)

--- a/Benny-Scraper/Program.cs
+++ b/Benny-Scraper/Program.cs
@@ -258,8 +258,8 @@ namespace Benny_Scraper
                     break;
                 try
                 {
-                    ++count;
                     await novelProcessor.ProcessNovelAsync(new Uri(novel.Url));
+                    ++count;
                     updatedNovels.Add((count, novel.Title));
                 }
                 catch (Exception ex)
@@ -275,6 +275,11 @@ namespace Benny_Scraper
                 }
             }
             Console.WriteLine("Completed novels: " + count);
+            foreach (var updateNovel in updatedNovels)
+            {
+                Console.BackgroundColor = ConsoleColor.Green;
+                Console.WriteLine($"{updateNovel.Item1}) {updateNovel.Item2}");
+            }
         }
 
         private static Task HandleParseErrors(IEnumerable<Error> errors)

--- a/Benny-Scraper/Properties/launchSettings.json
+++ b/Benny-Scraper/Properties/launchSettings.json
@@ -6,7 +6,6 @@
     },
     "Benny-Scraper": {
       "commandName": "Project",
-      "commandLineArgs": "-u",
       "nativeDebugging": true
     }
   }


### PR DESCRIPTION
1. Updated to .NET 8.0 and packages along with it.
2. Add new command line option `-U` or `--update-all` which will update all novels in the database that are not completed and were not modified the same day as the command is ran. *This does leave out https://mangareader.to/ until #37 can be resolved.*
3. Changed most of the `Info` level logging to be `Debug` so there will be less text that show while a novel is being processed.
4. Resolved issue when comparing if a new chapter found online is the same as a saved one, which incorrectly passed 0 chapters to the update method.